### PR TITLE
Added markdown rendering to LOOT tooltips

### DIFF
--- a/src/views/DependencyIcon.tsx
+++ b/src/views/DependencyIcon.tsx
@@ -16,6 +16,7 @@ import {
   DropTarget, DropTargetConnector, DropTargetMonitor, DropTargetSpec,
 } from 'react-dnd';
 import { getEmptyImage } from 'react-dnd-html5-backend';
+import ReactMarkdown from 'react-markdown';
 import { findDOMNode } from 'react-dom';
 import { connect } from 'react-redux';
 import { Advanced, ComponentEx, log, selectors, tooltip, util } from 'vortex-api';
@@ -403,7 +404,7 @@ class DependencyIcon extends ComponentEx<IProps, IComponentState> {
       : ref;
 
     if (readOnly) {
-      return <li key={name} className='rule-readonly'>{display || name}</li>;
+      return <li key={name} className='rule-readonly'><ReactMarkdown>{display || name}</ReactMarkdown></li>;
     }
 
     return (


### PR DESCRIPTION
LOOT dependency data is often written in markdown. This changes:

`**Skyrim Script Extender ([ SKSE 64 ](https://skse.silverlock.org))**` to **Skyrim Script Extender ([ SKSE 64 ](https://skse.silverlock.org))**

(SkyUI_SE.esp is the example case)