### PR TITLE
Decouple PluginList.tsx and MasterList.tsx 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
   nativePlugins,
   pluginExtensions,
   pluginPath,
+  revisionText,
   supportedGames,
   supportsESL,
 } from './util/gameSupport';
@@ -316,6 +317,7 @@ function register(context: IExtensionContextExt,
       minRevision,
       supportsESL,
       getPluginFlags,
+      revisionText,
       forceListUpdate,
       nativePlugins: gameSupported(selectors.activeGameId(context.api.store.getState()))
         ? nativePlugins(selectors.activeGameId(context.api.store.getState()))

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ import * as nodeUtil from 'util';
 import { actions, fs, log, selectors, types, util } from 'vortex-api';
 import { getPluginFlags } from './views/PluginFlags';
 import { createSelector } from 'reselect';
+import { IESPFile } from './types/IESPFile';
 
 type TranslationFunction = typeof I18next.t;
 
@@ -330,7 +331,9 @@ function register(context: IExtensionContextExt,
 
   const openLOOTSite = () => util.opn('https://loot.github.io/').catch(() => null)
 
-  const getNewESPFile = (filePath: string) => new ESPFile(filePath);
+  const parseESPFile = (filePath: string): IESPFile => ({
+    ...new ESPFile(filePath)
+  })
 
   const safeBasename = (filePath: string) => {
     return filePath !== undefined
@@ -365,8 +368,7 @@ function register(context: IExtensionContextExt,
       isMaster,
       isLight,
       openLOOTSite,
-      getNewESPFile,
-      pathExtname: path.extname,
+      parseESPFile,
       forceListUpdate,
       safeBasename,
       installedPlugins,

--- a/src/index.ts
+++ b/src/index.ts
@@ -307,6 +307,36 @@ function register(context: IExtensionContextExt,
     ['session', 'base', 'activity', 'plugins'],
   ], (activity: string[]) => (activity !== undefined) && (activity.length > 0));
 
+  const isMaster = (filePath: string, flag: boolean, gameMode: string): boolean => {
+    if (path.extname(filePath) === GHOST_EXT) {
+      filePath = path.basename(filePath, GHOST_EXT);
+    }
+    const masterExts = supportsESL(gameMode)
+      ? ['.esm', '.esl']
+      : ['.esm'];
+    return flag || (masterExts.indexOf(path.extname(filePath).toLowerCase()) !== -1);
+  };
+
+  const isLight = (filePath: string, flag: boolean, gameMode: string) => {
+    if (path.extname(filePath) === GHOST_EXT) {
+      filePath = path.basename(filePath, GHOST_EXT);
+    }
+    if (!supportsESL(gameMode)) {
+      return false;
+    }
+    return flag || (path.extname(filePath).toLowerCase() === '.esl');
+  };
+
+  const openLOOTSite = () => util.opn('https://loot.github.io/').catch(() => null)
+
+  const getNewESPFile = (filePath: string) => new ESPFile(filePath);
+
+  const safeBasename = (filePath: string) => {
+    return filePath !== undefined
+      ? path.basename(filePath, GHOST_EXT)
+      : '';
+  }
+
   context.registerMainPage('plugins', 'Plugins', PluginList, {
     id: 'gamebryo-plugins',
     hotkey: 'E',
@@ -318,7 +348,13 @@ function register(context: IExtensionContextExt,
       supportsESL,
       getPluginFlags,
       revisionText,
+      isMaster,
+      isLight,
+      openLOOTSite,
+      getNewESPFile,
+      pathExtname: path.extname,
       forceListUpdate,
+      safeBasename,
       nativePlugins: gameSupported(selectors.activeGameId(context.api.store.getState()))
         ? nativePlugins(selectors.activeGameId(context.api.store.getState()))
         : [],

--- a/src/types/IESPFile.ts
+++ b/src/types/IESPFile.ts
@@ -1,0 +1,10 @@
+export interface IESPFile  {
+  // setLightFlag(enabled: boolean): void;
+  isMaster: boolean;
+  isLight: boolean;
+  isDummy: boolean;
+  author: string;
+  description: string;
+  masterList: string[];
+  revision: number;
+}

--- a/src/views/MasterList.tsx
+++ b/src/views/MasterList.tsx
@@ -1,20 +1,12 @@
-import { gameSupported, nativePlugins } from '../util/gameSupport';
-
 import * as React from 'react';
 import { ListGroup, ListGroupItem } from 'react-bootstrap';
-import { connect } from 'react-redux';
-import { createSelector } from 'reselect';
-import { selectors } from 'vortex-api';
 
 interface IBaseProps {
   masters: string[];
-}
-
-interface IConnectedProps {
   installedPlugins: Set<string>;
 }
 
-type IProps = IBaseProps & IConnectedProps;
+type IProps = IBaseProps;
 
 class MasterList extends React.Component<IProps, {}> {
   constructor(props: IProps) {
@@ -45,23 +37,4 @@ class MasterList extends React.Component<IProps, {}> {
       </ListGroupItem>);
   }
 }
-
-const loadOrder = (state) => state.loadOrder;
-
-const enabledPlugins = createSelector(loadOrder, selectors.activeGameId, (order, gameId) => {
-  if (!gameSupported(gameId)) {
-    return new Set<string>([]);
-  }
-  return new Set<string>([].concat(nativePlugins(gameId), Object.keys(order)
-    .filter((pluginName: string) => order[pluginName].enabled)
-    .map((pluginName: string) => pluginName.toLowerCase()),
-  ));
-});
-
-function mapStateToProps(state: any): IConnectedProps {
-  return {
-    installedPlugins: enabledPlugins(state),
-  };
-}
-
-export default connect(mapStateToProps)(MasterList) as React.ComponentClass<IBaseProps>;
+export default MasterList;

--- a/src/views/PluginList.tsx
+++ b/src/views/PluginList.tsx
@@ -79,7 +79,8 @@ interface IBaseProps {
   openLOOTSite: () => Promise<any>;
   getNewESPFile: (filePath: string) => ESPFile;
   pathExtname: (p: string) => string;
-  safeBasename: (filePath: string) => string
+  safeBasename: (filePath: string) => string;
+  installedPlugins: () => Set<string>;
 }
 
 interface IConnectedProps {
@@ -1403,7 +1404,9 @@ class PluginList extends ComponentEx<IProps, IComponentState> {
         name: 'Masters',
         edit: {},
         customRenderer: (plugin: IPluginCombined, detail: boolean, t: TranslationFunction) =>
-          <MasterList masters={plugin.masterList} />,
+          <MasterList
+            masters={plugin.masterList} 
+            installedPlugins={this.props.installedPlugins()} />,
         calc: (plugin: IPluginCombined) => plugin.masterList,
         placement: 'detail',
       },

--- a/src/views/PluginList.tsx
+++ b/src/views/PluginList.tsx
@@ -668,7 +668,6 @@ class PluginList extends ComponentEx<IProps, IComponentState> {
       return new Promise((resolve, reject) => {
         try {
           const esp = this.props.parseESPFile(pluginsIn[pluginName].filePath);
-          console.log('EspFile', esp);
           pluginsParsed[pluginName] = {
             isMaster: this.props.isMaster(
               pluginsIn[pluginName].filePath, esp.isMaster, this.props.gameMode


### PR DESCRIPTION
I decupled path.extname by create `pathExtname` prop. 
I was not sure about manually replacing it using `endsWith` or similar function, so, for safety, I just made the function a prop. 
If you want it nearly 100% compatible, then we should use this: https://www.npmjs.com/package/path-browserify

No extra comment for the other stuff