### PR TITLE
updating masterlist revision

### DIFF
--- a/src/util/masterlist.ts
+++ b/src/util/masterlist.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { fs, util } from 'vortex-api';
 
-const LOOT_LIST_REVISION = 'v0.18';
+const LOOT_LIST_REVISION = 'v0.21';
 
 // TODO: this is for transitioning from loot 0.17 -> 0.18, remove it at some point
 async function tryRemoveDotGit(localPath: string) {


### PR DESCRIPTION
LOOT API version is 0.22.1; for some reason the masterlist revision is currently still on "v0.21" perhaps they'll update to 0.22 once Starfield modding is more robust? 🤷 