### PR TITLE
fixed loot error when removing mods on startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamebryo-plugin-management",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "description": "Management for gamebryo plugins",
   "main": "./out/index.js",
   "repository": "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -670,7 +670,7 @@ function startSyncRemote(api: types.IExtensionApi): Promise<void> {
 
               refreshTimer = setTimeout(() => {
                 updateCurrentProfile(store)
-                  .then(() => api.events.emit('autosort-plugins', false));
+                  .then(() => api.events.emit('autosort-plugins', true));
                 refreshTimer = undefined;
               }, 500);
             }


### PR DESCRIPTION
The lists and plugins were not yet loaded if/when attempting to remove a mod immediately on application start-up.

fixes nexus-mods/vortex#17593