### PR TITLE
fixed sorting action failing if an invalid plugin is detected

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamebryo-plugin-management",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Management for gamebryo plugins",
   "main": "./out/index.js",
   "repository": "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -670,7 +670,6 @@ function startSyncRemote(api: types.IExtensionApi): Promise<void> {
 
               refreshTimer = setTimeout(() => {
                 updateCurrentProfile(store)
-                  .then(() => api.events.emit('autosort-plugins', true));
                 refreshTimer = undefined;
               }, 500);
             }
@@ -1416,6 +1415,11 @@ function init(context: IExtensionContextExt) {
           pluginsChangedQueued = true;
         } else {
           context.api.events.emit('trigger-test-run', 'plugins-changed', 500);
+          updateCurrentProfile(store)
+            .then(() => context.api.events.emit('autosort-plugins', false))
+            .catch(err => {
+              context.api.showErrorNotification('Failed to update plugin list', err);
+            });
         }
       });
 

--- a/src/views/PluginList.tsx
+++ b/src/views/PluginList.tsx
@@ -1298,7 +1298,9 @@ class PluginList extends ComponentEx<IProps, IComponentState> {
         isToggleable: false,
         edit: {},
         isSortable: true,
-        calc: (plugin: IPluginCombined) => plugin.loadOrder !== -1 ? plugin.loadOrder : '?',
+        calc: (plugin: IPluginCombined) => plugin.loadOrder !== -1
+          ? plugin.loadOrder
+          : this.props.loadOrder[plugin.id]?.loadOrder ?? '?',
         sortFuncRaw: (lhs, rhs) => this.sortByLoadOrder(this.installedNative, lhs, rhs),
         placement: 'table',
       },


### PR DESCRIPTION
- sorting will now continue even if an invalid plugin is detected
- invalid plugins should be removed by the user
- fixed instances where plugins were disabled upon mod installation/activation