### PR TITLE
fixed autosort on mod install + light/regular issue to some degree

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamebryo-plugin-management",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Management for gamebryo plugins",
   "main": "./out/index.js",
   "repository": "",

--- a/src/autosort.ts
+++ b/src/autosort.ts
@@ -113,7 +113,7 @@ class LootInterface {
 
   private shouldDeferLootActivities = () => {
     const state = this.mExtensionApi.store.getState();
-    const deferOnActivities = ['installing_dependencies', 'mods'];
+    const deferOnActivities = ['installing_dependencies'];
     const isActivityRunning = (activity: string) => util.getSafe(state, ['session', 'base', 'activity', activity], []).length > 0;
     const deferActivities = deferOnActivities.filter(activity => isActivityRunning(activity));
     return deferActivities.length > 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,16 +95,6 @@ function isPlugin(filePath: string, fileName: string, gameMode: string): Promise
     .catch(util.UserCanceled, () => false);
 }
 
-function updatePlugins(api: IExtensionApi): Promise<void> {
-    const profile = selectors.activeProfile(api.getState());
-    return new Promise<void>(async (resolve, reject) => {
-      await updatePluginList(api.store, profile.modState, profile.gameId);
-      const pluginList = util.getSafe(api.getState(), ['session', 'plugins', 'pluginList'], {});
-      api.events.emit('plugin-details', profile.gameId, Object.keys(pluginList ?? {}), resolve);
-    })
-    .tap(() => api.events.emit('autosort-plugins', false));
-}
-
 /**
  * updates the list of known plugins for the managed game
  */
@@ -1298,6 +1288,7 @@ function onDidDeploy(api: types.IExtensionApi, profileId: string): Promise<void>
         const pluginList = util.getSafe(api.getState(), ['session', 'plugins', 'pluginList'], {});
         api.events.emit('plugin-details', profile.gameId, Object.keys(pluginList ?? {}), resolve);
       }))
+      .then(() => Promise.delay(1000)) // wait a bit for the plugin details to be updated
       .then(() => api.events.emit('autosort-plugins', false))
       .then(() => Promise.resolve())
     : Promise.resolve();


### PR DESCRIPTION
We use libloot to decide what can be marked light/regular. If libloot states that a plugin can't be marked, that's not something we can sort out on Vortex's end.