### PR TITLE
fixed plugin info not retrieved if plugin contains no metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamebryo-plugin-management",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Management for gamebryo plugins",
   "main": "./out/index.js",
   "repository": "",

--- a/src/autosort.ts
+++ b/src/autosort.ts
@@ -482,11 +482,6 @@ class LootInterface {
       }
       try {
         const meta: PluginMetadata = await loot.getPluginMetadataAsync(pluginName);
-        if (!meta) {
-          // no metadata available, this is not an error, just means loot doesn't know about it
-          result[pluginName] = createEmpty();
-          return;
-        }
         let info;
         try {
           const id = pluginName.toLowerCase();


### PR DESCRIPTION
fixes nexus-mods/vortex#17962